### PR TITLE
Add dropdowns for Django routes and stops

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -26,6 +26,14 @@ class RutaViewSet(viewsets.ModelViewSet):
 
     permission_classes = [IsAuthenticated]
 
+    @action(detail=True, methods=['get'])
+    def paradas(self, request, pk=None):
+        """Retorna las paradas asociadas a una ruta."""
+        ruta = self.get_object()
+        paradas = ruta.paradas.all()
+        serializer = ParadaSerializer(paradas, many=True)
+        return Response(serializer.data)
+
     @action(detail=False, methods=['get'])
     def sync(self, request):
         since = request.query_params.get('since')

--- a/rutas-admin/public/panel.html
+++ b/rutas-admin/public/panel.html
@@ -31,6 +31,16 @@
         <option value="API">API Django</option>
       </select>
 
+      <!-- SELECT DE RUTAS (API Django) -->
+      <select id="rutas-api-select" style="display: none;">
+        <option value="">-- Cargando rutas... --</option>
+      </select>
+
+      <!-- SELECT DE PARADAS POR RUTA (API Django) -->
+      <select id="paradas-api-select" style="display: none;">
+        <option value="">-- Seleccione ruta --</option>
+      </select>
+
       <!-- 1) SELECT DE RUTAS (GET SIMON) -->
       <select id="rutas-select">
         <option value="">-- Cargando rutas... --</option>


### PR DESCRIPTION
## Summary
- expose route stops via `/api/rutas/<id>/paradas/`
- show Django routes and their stops in the admin panel
- display markers for each stop when selecting a route

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6846609ef7648321b1f7e07c6ba72be1